### PR TITLE
Adding a plugin for easy FAQ handling

### DIFF
--- a/plugins/zzz-more/README.md
+++ b/plugins/zzz-more/README.md
@@ -11,6 +11,9 @@ Plugins by the [Yellow community](https://github.com/datenstrom/yellow/wiki/Yell
 * [dynamiccss](https://github.com/richi/yellowcms-dynamiccss)  
   Yellow plugin with a small preprocessor for your CSS files.
 
+* [faq](https://github.com/richi/yellowcms-faq)  
+  Yellow plugin for easy FAQ handling.
+
 * [markbar](https://github.com/nibreh/yellowcms-markbar)  
   Yellow plugin with a WYSIWYG style toolbar for editing a page. 
 


### PR DESCRIPTION
Users or customers have tons of common questions
that have to be answered over and over again.
This plugin was made to manage these frequently
asked questions in a convenient way.