### PR TITLE
Bugfix: deleteDirectory won't delete targets of symlinks

### DIFF
--- a/features/core/core.php
+++ b/features/core/core.php
@@ -2577,12 +2577,10 @@ class YellowToolbox {
             $iterator = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
             $files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($files as $file) {
-                if ($file->isLink()) {
-                    @unlink($file->getPathname());
-                } elseif ($file->isDir()) {
-                    @rmdir($file->getRealPath());
+                if ($file->getType() == "dir") {
+                    @rmdir($file->getPathname());
                 } else {
-                    @unlink($file->getRealPath());
+                    @unlink($file->getPathname());
                 }
             }
             $ok = @rmdir($path);

--- a/features/core/core.php
+++ b/features/core/core.php
@@ -2577,7 +2577,9 @@ class YellowToolbox {
             $iterator = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
             $files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($files as $file) {
-                if ($file->isDir()) {
+                if ($file->isLink()) {
+                    @unlink($file->getPathname());
+                } elseif ($file->isDir()) {
                     @rmdir($file->getRealPath());
                 } else {
                     @unlink($file->getRealPath());


### PR DESCRIPTION
In its current state, `YellowToolbox::deleteDirectory()` does not delete any symlink in the directory. Instead, it tries to delete the *target* of the symlink, because of `getRealPath()`. If the target is a file or an empty dir, then it's deleted and all that's left in the directory is a broken link (and this broken link prevents the dir to be removed by `rmdir()`).

This commit fixes that behaviour by deleting the *link*, keeping the target intact. The directory is then removed with `rmdir()` as expected.