### PR TITLE
Add feature to set from address for contact extension

### DIFF
--- a/source/contact/contact.php
+++ b/source/contact/contact.php
@@ -10,6 +10,7 @@ class YellowContact {
         $this->yellow = $yellow;
         $this->yellow->system->setDefault("contactLocation", "/contact/");
         $this->yellow->system->setDefault("contactEmailRestriction", "0");
+        $this->yellow->system->setDefault("contactEmailFrom", "noreply");
         $this->yellow->system->setDefault("contactLinkRestriction", "0");
         $this->yellow->system->setDefault("contactSpamFilter", "advert|promot|market|traffic|click here");
         $this->yellow->language->setDefault("contactMailHeader");
@@ -73,6 +74,7 @@ class YellowContact {
         $spamFilter = $this->yellow->system->get("contactSpamFilter");
         $author = $this->yellow->system->get("author");
         $email = $this->yellow->system->get("email");
+        $emailfrom = $this->yellow->system->get("ContactEmailFrom");
         if ($this->yellow->page->isExisting("author") && !$this->yellow->system->get("contactEmailRestriction")) {
             $author = $this->yellow->page->get("author");
         }
@@ -86,7 +88,7 @@ class YellowContact {
         if ($status=="send") {
             $mailTo = mb_encode_mimeheader("$author")." <$email>";
             $mailSubject = mb_encode_mimeheader($this->yellow->page->get("title"));
-            $mailHeaders = mb_encode_mimeheader("From: $sitename")." <noreply>\r\n";
+            $mailHeaders = mb_encode_mimeheader("From: $sitename")." <$emailfrom>\r\n";
             $mailHeaders .= mb_encode_mimeheader("Reply-To: $name")." <$from>\r\n";
             $mailHeaders .= mb_encode_mimeheader("X-Referer-Url: ".$referer)."\r\n";
             $mailHeaders .= mb_encode_mimeheader("X-Request-Url: ".$this->yellow->page->getUrl())."\r\n";

--- a/source/contact/contact.php
+++ b/source/contact/contact.php
@@ -10,7 +10,7 @@ class YellowContact {
         $this->yellow = $yellow;
         $this->yellow->system->setDefault("contactLocation", "/contact/");
         $this->yellow->system->setDefault("contactEmailRestriction", "0");
-        $this->yellow->system->setDefault("contactEmailFrom", "noreply");
+        $this->yellow->system->setDefault("contactSiteEmail", "noreply");
         $this->yellow->system->setDefault("contactLinkRestriction", "0");
         $this->yellow->system->setDefault("contactSpamFilter", "advert|promot|market|traffic|click here");
         $this->yellow->language->setDefault("contactMailHeader");
@@ -74,7 +74,7 @@ class YellowContact {
         $spamFilter = $this->yellow->system->get("contactSpamFilter");
         $author = $this->yellow->system->get("author");
         $email = $this->yellow->system->get("email");
-        $emailfrom = $this->yellow->system->get("ContactEmailFrom");
+        $emailfrom = $this->yellow->system->get("contactSiteEmail");
         if ($this->yellow->page->isExisting("author") && !$this->yellow->system->get("contactEmailRestriction")) {
             $author = $this->yellow->page->get("author");
         }

--- a/source/edit/edit.php
+++ b/source/edit/edit.php
@@ -29,6 +29,7 @@ class YellowEdit {
         $this->yellow->system->setDefault("editLoginSessionTimeout", "2592000");
         $this->yellow->system->setDefault("editBruteForceProtection", "25");
         $this->yellow->language->setDefault("editMailFooter");
+        $this->yellow->system->setDefault("editSiteEmail", "noreply");
     }
     
     // Handle update
@@ -1561,6 +1562,7 @@ class YellowEditResponse {
     
     // Send mail to user
     public function sendMail($scheme, $address, $base, $email, $action) {
+        $emailfrom = $this->yellow->system->editSiteEmail");
         if ($action=="approve") {
             $userName = $this->yellow->system->get("author");
             $userEmail = $this->yellow->system->get("email");
@@ -1591,7 +1593,7 @@ class YellowEditResponse {
         $footer = preg_replace("/@sitename/i", $sitename, $footer);
         $mailTo = mb_encode_mimeheader("$userName")." <$userEmail>";
         $mailSubject = mb_encode_mimeheader($this->yellow->language->getText("{$prefix}Subject", $userLanguage));
-        $mailHeaders = mb_encode_mimeheader("From: $sitename")." <noreply>\r\n";
+        $mailHeaders = mb_encode_mimeheader("From: $sitename")." <$emailfrom>\r\n";
         $mailHeaders .= mb_encode_mimeheader("X-Request-Url: $scheme://$address$base")."\r\n";
         $mailHeaders .= "Mime-Version: 1.0\r\n";
         $mailHeaders .= "Content-Type: text/plain; charset=utf-8\r\n";

--- a/source/edit/edit.php
+++ b/source/edit/edit.php
@@ -1562,7 +1562,7 @@ class YellowEditResponse {
     
     // Send mail to user
     public function sendMail($scheme, $address, $base, $email, $action) {
-        $emailfrom = $this->yellow->system->editSiteEmail");
+        $emailfrom = $this->yellow->system->get("editSiteEmail");
         if ($action=="approve") {
             $userName = $this->yellow->system->get("author");
             $userEmail = $this->yellow->system->get("email");


### PR DESCRIPTION
I have added the option to set the from address to the contact extension. This improves the usability with sender/from restrictions on a lot of mailservers.